### PR TITLE
update `goron elder` logic

### DIFF
--- a/logic/labrynna.yaml
+++ b/logic/labrynna.yaml
@@ -123,7 +123,7 @@ d4 entrance: [symmetry present, tuni nut, patch]
 # rolling ridge. what a nightmare
 goron elder: [bomb flower, or: [
     ridge west past,
-    [lynna village, or: [feather, ages], or: [switch hook, cape, [hard, magnet gloves]]]]
+    [lynna village, or: [feather, ages], or: [switch hook, cape, [hard, magnet gloves]]]]]
 ridge west past: {or: [
     goron elder,
     [ridge west present, or: [ages, [bracelet, echoes]]]]}

--- a/logic/labrynna.yaml
+++ b/logic/labrynna.yaml
@@ -123,7 +123,7 @@ d4 entrance: [symmetry present, tuni nut, patch]
 # rolling ridge. what a nightmare
 goron elder: [bomb flower, or: [
     ridge west past,
-    [lynna village, or: [feather, ages], or: [switch hook, cape]]]]
+    [lynna village, or: [feather, ages], or: [switch hook, cape, [hard, magnet gloves]]]]
 ridge west past: {or: [
     goron elder,
     [ridge west present, or: [ages, [bracelet, echoes]]]]}


### PR DESCRIPTION
with the introduction of cross-items, you can now use magnet gloves to cross the switchhook gap by the goron elder. since its a bit tricky, i threw it in with hard logic. first of many new magnet glove tricks im sure will happen.  link to trick demonstration -> https://discord.com/channels/148183213272072192/523574765160628245/1068457269525749801